### PR TITLE
addressing my own complaints

### DIFF
--- a/examples/basic_experiment.py
+++ b/examples/basic_experiment.py
@@ -26,7 +26,7 @@ tone *= 0.01 * np.sqrt(2)  # Set RMS to 0.01
 
 with ExperimentController('testExp', participant='foo', session='001',
                           output_dir=None) as ec:
-    ec.screen_prompt('Press a button to hear the tone')
+    ec.screen_prompt('Press a button when you hear the tone', max_wait=1)
 
     dot = FixationDot(ec)
     ec.clear_buffer()
@@ -39,7 +39,7 @@ with ExperimentController('testExp', participant='foo', session='001',
     presses = ec.wait_for_presses(dur)
     ec.stop()
     ec.trial_ok()
-    print('Presses:\n%s' % presses)
+    print('Presses:\n{}'.format(presses))
 
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
change %s to .format(), changes to instructions. 

With `basic_experiment` I'm also occasionally getting `thread.error`s in the existing console window when I hit `F5` in Spyder to re-run the code after making changes. I _think_ this is a pyglet problem (remember seeing pyglet in the traceback) but I was unable to copy/paste the error and traceback because it hangs the system for several seconds, then as soon as it unhangs, the python session ends and it starts a fresh one.
