### PR TITLE
MRG: fix tests that failed on Windows+TDT

### DIFF
--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -247,9 +247,7 @@ def test_ec(ac=None, rd=None):
         click[len(click) // 2] = 1.
         click[len(click) // 2 + 1] = -1.
         # noise: RMS 0.03, should fail both 'fullfile' and 'windowed'
-        nsamp = int(ec.fs / 8)
-        noise = np.random.normal(scale=0.03, size=(nsamp,))
-        dur = nsamp / ec.fs
+        noise = np.random.normal(scale=0.03, size=(int(ec.fs / 4),))
         ec.set_rms_checking(None)
         ec.load_buffer(click)  # should go unchecked
         ec.load_buffer(noise)  # should go unchecked
@@ -276,7 +274,6 @@ def test_ec(ac=None, rd=None):
         #
         assert_raises(RuntimeError, ec.start_stimulus)  # order violation
         ec.start_stimulus(start_of_trial=False)         # should work
-        ec.wait_secs(dur)  # othewise ec._playing bites us later
         assert_raises(RuntimeError, ec.trial_ok)        # order violation
         ec.stop()
         # only binary for TTL
@@ -304,23 +301,19 @@ def test_ec(ac=None, rd=None):
         # double-check
         assert_raises(RuntimeError, ec.start_stimulus)  # order violation
         ec.start_stimulus(start_of_trial=False)         # should work
-        ec.wait_secs(dur)  # othewise ec._playing bites us later
         assert_raises(RuntimeError, ec.trial_ok)        # order violation
         ec.stop()
 
         ec.flip(-np.inf)
         ec.estimate_screen_fs()
         ec.play()
-        ec.wait_secs(dur)  # othewise ec._playing bites us later
         ec.call_on_every_flip(None)
         ec.call_on_next_flip(ec.start_noise())
         ec.stop()
         ec.start_stimulus(start_of_trial=False)
-        ec.wait_secs(dur)  # othewise ec._playing bites us later
         ec.call_on_next_flip(ec.stop_noise())
         ec.stop()
         ec.start_stimulus(start_of_trial=False)
-        ec.wait_secs(dur)  # othewise ec._playing bites us later
         ec.get_mouse_position()
         ec.listen_clicks()
         ec.get_clicks()

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -280,7 +280,11 @@ def test_ec(ac=None, rd=None):
         assert_raises(KeyError, ec.identify_trial, ec_id='foo')  # need ttl_id
         assert_raises(TypeError, ec.identify_trial, ec_id='foo', ttl_id='bar')
         assert_raises(ValueError, ec.identify_trial, ec_id='foo', ttl_id=[2])
+        print('283: playing: {}, progress: {} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+              '!!!!!'.format(ec._playing, ec._trial_progress))
         ec.identify_trial(ec_id='foo', ttl_id=[0, 1])
+        print('286: playing: {}, progress: {} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+              '!!!!!'.format(ec._playing, ec._trial_progress))
         #
         # Second: start_stimuli
         #
@@ -360,8 +364,8 @@ def test_button_presses_and_window_size():
     warnings.simplefilter('ignore')  # esc as quit key
     with ExperimentController(*std_args, audio_controller='pyglet',
                               response_device='keyboard', window_size=None,
-                              output_dir=None, full_screen=False,
-                              participant='foo', session='01',
+                              output_dir=None, full_screen=False, session='01',
+                              participant='foo', trigger_controller='dummy',
                               force_quit='escape', version='dev') as ec:
         warnings.simplefilter('always')
         fake_button_press(ec, '1', 0.3)
@@ -411,21 +415,21 @@ def test_background_color():
     with ExperimentController(*std_args, participant='foo', session='01',
                               output_dir=None, version='dev') as ec:
         ec.set_background_color('red')
-        ec.screen_text('red', color='white')
         ss = ec.screenshot()[:, :, :3]
-        white_mask = (ss == [255] * 3)
-        assert_true(white_mask.any())
-        red_mask = (ss == [255, 0, 0])
-        assert_true(red_mask.any())
-        assert_true(np.logical_or(white_mask, red_mask).all())
+        red_mask = (ss == [255, 0, 0]).all(axis=-1)
+        assert_true(red_mask.all())
+        ec.set_background_color('white')
+        ss = ec.screenshot()[:, :, :3]
+        white_mask = (ss == [255] * 3).all(axis=-1)
+        assert_true(white_mask.all())
         ec.flip()
-
         ec.set_background_color('0.5')
         visual.Rectangle(ec, [0, 0, 1, 1], fill_color='black').draw()
         ss = ec.screenshot()[:, :, :3]
-        gray_mask = (ss == [127] * 3) | (ss == [128] * 3)
+        gray_mask = ((ss == [127] * 3).all(axis=-1) |
+                     (ss == [128] * 3).all(axis=-1))
         assert_true(gray_mask.any())
-        black_mask = (ss == [0] * 3)
+        black_mask = (ss == [0] * 3).all(axis=-1)
         assert_true(black_mask.any())
         assert_true(np.logical_or(gray_mask, black_mask).all())
 

--- a/expyfun/tests/test_experiment_controller.py
+++ b/expyfun/tests/test_experiment_controller.py
@@ -247,7 +247,9 @@ def test_ec(ac=None, rd=None):
         click[len(click) // 2] = 1.
         click[len(click) // 2 + 1] = -1.
         # noise: RMS 0.03, should fail both 'fullfile' and 'windowed'
-        noise = np.random.normal(scale=0.03, size=(int(ec.fs / 4),))
+        nsamp = int(ec.fs / 8)
+        noise = np.random.normal(scale=0.03, size=(nsamp,))
+        dur = nsamp / ec.fs
         ec.set_rms_checking(None)
         ec.load_buffer(click)  # should go unchecked
         ec.load_buffer(noise)  # should go unchecked
@@ -274,17 +276,14 @@ def test_ec(ac=None, rd=None):
         #
         assert_raises(RuntimeError, ec.start_stimulus)  # order violation
         ec.start_stimulus(start_of_trial=False)         # should work
+        ec.wait_secs(dur)  # othewise ec._playing bites us later
         assert_raises(RuntimeError, ec.trial_ok)        # order violation
         ec.stop()
         # only binary for TTL
         assert_raises(KeyError, ec.identify_trial, ec_id='foo')  # need ttl_id
         assert_raises(TypeError, ec.identify_trial, ec_id='foo', ttl_id='bar')
         assert_raises(ValueError, ec.identify_trial, ec_id='foo', ttl_id=[2])
-        print('283: playing: {}, progress: {} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-              '!!!!!'.format(ec._playing, ec._trial_progress))
         ec.identify_trial(ec_id='foo', ttl_id=[0, 1])
-        print('286: playing: {}, progress: {} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-              '!!!!!'.format(ec._playing, ec._trial_progress))
         #
         # Second: start_stimuli
         #
@@ -305,19 +304,23 @@ def test_ec(ac=None, rd=None):
         # double-check
         assert_raises(RuntimeError, ec.start_stimulus)  # order violation
         ec.start_stimulus(start_of_trial=False)         # should work
+        ec.wait_secs(dur)  # othewise ec._playing bites us later
         assert_raises(RuntimeError, ec.trial_ok)        # order violation
         ec.stop()
 
         ec.flip(-np.inf)
         ec.estimate_screen_fs()
         ec.play()
+        ec.wait_secs(dur)  # othewise ec._playing bites us later
         ec.call_on_every_flip(None)
         ec.call_on_next_flip(ec.start_noise())
         ec.stop()
         ec.start_stimulus(start_of_trial=False)
+        ec.wait_secs(dur)  # othewise ec._playing bites us later
         ec.call_on_next_flip(ec.stop_noise())
         ec.stop()
         ec.start_stimulus(start_of_trial=False)
+        ec.wait_secs(dur)  # othewise ec._playing bites us later
         ec.get_mouse_position()
         ec.listen_clicks()
         ec.get_clicks()

--- a/expyfun/tests/test_logging.py
+++ b/expyfun/tests/test_logging.py
@@ -21,6 +21,7 @@ def test_logging(ac='pyglet'):
     try:
         with ExperimentController(*std_args, audio_controller=ac,
                                   response_device='keyboard',
+                                  trigger_controller='dummy',
                                   **std_kwargs) as ec:
             test_name = ec._log_file
             stamp = ec.current_time


### PR DESCRIPTION
this doesn't yet address the `ec._playing` issue mentioned in labsn/expyfun#283