### PR TITLE
test presses at tmin/tmax limits

### DIFF
--- a/expyfun/analyze/tests/test_analyze_functions.py
+++ b/expyfun/analyze/tests/test_analyze_functions.py
@@ -48,9 +48,9 @@ def test_presses_to_hmfc():
     targets = [0., 1.]
     foils = [0.5, 1.5]
 
-    presses = [0.11, 1.3]
+    presses = [0.1, 1.6]  # presses right at tmin/tmax
     hmfco = [2, 0, 0, 2, 0]
-    rts = [[0.11, 0.3], []]
+    rts = [[0.1, 0.6], []]
     assert_hmfc(presses, targets, foils, hmfco, rts)
 
     presses = [0.65, 1.601]  # just past the boundary


### PR DESCRIPTION
This fails, and shouldn't.  Granted it's an edge case, where a press at `1.6` could be a 600ms RT to a targ at `1.0` or a 100ms RT to a foil at `1.5`.  What is strange about it is the nosetests traceback; here's what fails:

`>>  assert all(array([ 0.6]) <= 0.6)`