### PR TITLE
change "subject" to "participant" in log lines

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -388,7 +388,7 @@ class ExperimentController(object):
 
             # finish initialization
             logger.info('Expyfun: Initialization complete')
-            logger.exp('Expyfun: Subject: {0}'
+            logger.exp('Expyfun: Participant: {0}'
                        ''.format(self._exp_info['participant']))
             logger.exp('Expyfun: Session: {0}'
                        ''.format(self._exp_info['session']))

--- a/expyfun/tests/test_logging.py
+++ b/expyfun/tests/test_logging.py
@@ -33,7 +33,8 @@ def test_logging(ac='pyglet'):
             data = '\n'.join(fid.readlines())
 
         # check for various expected log messages (TODO: add more)
-        should_have = ['Subject: foo', 'Session: 01', 'wait_until was called',
+        should_have = ['Participant: foo', 'Session: 01',
+                       'wait_until was called',
                        'Stimulus max RMS (']
         if ac == 'pyglet':
             should_have.append('Pyglet')


### PR DESCRIPTION
makes logged message more consistent with variable names.